### PR TITLE
[Hotfix] random transforming only one sample you not work properly 

### DIFF
--- a/minerva/transforms/random_transform.py
+++ b/minerva/transforms/random_transform.py
@@ -42,10 +42,11 @@ class _RandomSyncedTransform(_Transform):
     def __call__(self, data):
         if self.transformations_executed == 0:
             self.transform = self.select_transform()
-            self.transformations_executed += 1
+            if self.num_samples > 1:
+                self.transformations_executed += 1
             return self.transform(data)
         else:
-            if self.transformations_executed == self.num_samples:
+            if self.transformations_executed == self.num_samples - 1:
                 self.transformations_executed = 0
             else:
                 self.transformations_executed += 1

--- a/minerva/transforms/random_transform.py
+++ b/minerva/transforms/random_transform.py
@@ -45,7 +45,7 @@ class _RandomSyncedTransform(_Transform):
             self.transformations_executed += 1
             return self.transform(data)
         else:
-            if self.transformations_executed == self.num_samples - 1:
+            if self.transformations_executed == self.num_samples:
                 self.transformations_executed = 0
             else:
                 self.transformations_executed += 1

--- a/tests/transforms/test_random_flip.py
+++ b/tests/transforms/test_random_flip.py
@@ -92,3 +92,45 @@ def test_random__dont_flip_any_axis():
 
     # check if both axis are flipped
     assert np.allclose(flipped_x, x)
+
+def test_random_flip_different_transforms():
+    # Create a dummy input
+    x1 = np.random.rand(10, 20, 30)
+    x2 = x1.copy()
+    
+    flip_transform = RandomFlip(possible_axis=[0, 1], num_samples=1, seed=1)
+    flipped_x1 = flip_transform(x1)
+    flipped_x2 = flip_transform(x2)
+    
+    # Check if the flipped data has the same shape as the input
+    assert flipped_x1.shape == x1.shape
+    assert flipped_x2.shape == x2.shape
+    
+    # Check if the flipped data is different from the input
+    assert not np.array_equal(flipped_x1, x1)
+    assert not np.array_equal(flipped_x2, x2)
+
+    #Check if the flipped data is different from each other
+    assert not np.array_equal(flipped_x1, flipped_x2)
+
+def test_random_flip_equal_transforms():
+    # Create a dummy input
+    x1 = np.random.rand(10, 20, 30)
+    x2 = x1.copy()
+    
+    flip_transform = RandomFlip(possible_axis=[0, 1], num_samples=2, seed=0)
+    flipped_x1 = flip_transform(x1)
+    flipped_x2 = flip_transform(x2)
+    
+    # Check if the flipped data has the same shape as the input
+    assert flipped_x1.shape == x1.shape
+    assert flipped_x2.shape == x2.shape
+    
+    # Check if the flipped data is different from the input
+    assert not np.array_equal(flipped_x1, x1)
+    assert not np.array_equal(flipped_x2, x2)
+
+    #Check if the flipped data is equal to each other
+    assert np.array_equal(flipped_x1, flipped_x2)
+
+

--- a/tests/transforms/test_random_flip.py
+++ b/tests/transforms/test_random_flip.py
@@ -93,44 +93,36 @@ def test_random__dont_flip_any_axis():
     # check if both axis are flipped
     assert np.allclose(flipped_x, x)
 
+
 def test_random_flip_different_transforms():
     # Create a dummy input
     x1 = np.random.rand(10, 20, 30)
     x2 = x1.copy()
-    
+
     flip_transform = RandomFlip(possible_axis=[0, 1], num_samples=1, seed=1)
     flipped_x1 = flip_transform(x1)
     flipped_x2 = flip_transform(x2)
-    
+
     # Check if the flipped data has the same shape as the input
     assert flipped_x1.shape == x1.shape
     assert flipped_x2.shape == x2.shape
-    
-    # Check if the flipped data is different from the input
-    assert not np.array_equal(flipped_x1, x1)
-    assert not np.array_equal(flipped_x2, x2)
 
-    #Check if the flipped data is different from each other
+    # Check if the flipped data is different from each other
     assert not np.array_equal(flipped_x1, flipped_x2)
+
 
 def test_random_flip_equal_transforms():
     # Create a dummy input
     x1 = np.random.rand(10, 20, 30)
     x2 = x1.copy()
-    
+
     flip_transform = RandomFlip(possible_axis=[0, 1], num_samples=2, seed=0)
     flipped_x1 = flip_transform(x1)
     flipped_x2 = flip_transform(x2)
-    
+
     # Check if the flipped data has the same shape as the input
     assert flipped_x1.shape == x1.shape
     assert flipped_x2.shape == x2.shape
-    
-    # Check if the flipped data is different from the input
-    assert not np.array_equal(flipped_x1, x1)
-    assert not np.array_equal(flipped_x2, x2)
 
-    #Check if the flipped data is equal to each other
+    # Check if the flipped data is equal to each other
     assert np.array_equal(flipped_x1, flipped_x2)
-
-


### PR DESCRIPTION
# Describe your changes
 - Correct a bug that would prevent `RandomTranform` for `num_sample=1` would not work as expected.
 - Add tests to cover this case

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests to this functionality.
- [x] All tests are passing.
- [x] I have updated the documentation as needed.
- [x] I have followed the project's coding guidelines.