### PR TITLE
feat!(fastsiam): more faithful FastSiam implementation

### DIFF
--- a/minerva/models/ssl/fastsiam.py
+++ b/minerva/models/ssl/fastsiam.py
@@ -1,11 +1,7 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-import copy
 import lightning as L
-from PIL import Image
-from torchvision import transforms
-from typing import Optional, Any, Callable, Sequence
+from typing import Optional, Any, Sequence
 
 
 class SimSiamMLPHead(nn.Sequential):
@@ -104,16 +100,18 @@ class FastSiam(L.LightningModule):
         Hidden dimension for the projector and predictor networks, by default 512.
     out_dim : int, optional
         Output dimension for the projector and predictor networks, by default 128.
-    K : int, optional
-        Number of target_branch views to generate, by default 3.
-    momentum : float, optional
-        Momentum factor for updating the target_branch, by default 0.996.
+    flatten : bool, optional, default=True
+        Whether to flatten the output of the backbone model, by default True
+    avg_pooling: bool, optional, default=True
+        Whether to apply a global average pooling to the backbone output.
+        If flatten is True it will be applied before flattening, by default True
+    k : int, optional
+        Number of target views to use, it will k+1 total views, make sure your Dataset class yields k+1 views, by default 3
     lr : float, optional
-        Learning rate for the optimizer, by default 1e-3.
-    test_metric : Optional[Callable], optional
-        A callable to compute the test metric, by default None.
-    num_classes : Optional[int], optional
-        Number of classes for classification tasks, by default None.
+        Learning rate for the optimizer, by default 0.125
+    loss_fn : Callable, optional
+        Loss function used for training. Default is cosine similarity loss.
+        This loss will be multiplied by -1 when computing total loss
     """
 
     def __init__(
@@ -122,192 +120,108 @@ class FastSiam(L.LightningModule):
         in_dim: int = 2048,
         hid_dim: int = 2048,
         out_dim: int = 2048,
-        K: int = 3,
-        momentum: float = 0.996,
-        lr: float = 1e-3,
-        test_metric: Optional[Callable] = None,
-        num_classes: Optional[int] = None,
+        flatten: bool = True,
+        avg_pooling: bool = True,
+        k: int = 3,
+        lr: float = 0.125,
+        loss_fn: Optional[nn.Module] = None,
     ):
         super(FastSiam, self).__init__()
-        self.K = K
-        self.momentum = momentum
+        self.k = k
         self.lr = lr
-        self.test_metric = test_metric
-        self.num_classes = num_classes
+        self.out_dim = out_dim
+        self.flatten = flatten
 
-        # Prediction branch
         self.backbone = backbone
-        self.prediction_branch_projector = SimSiamMLPHead(
+        self.projection_head = SimSiamMLPHead(
             [in_dim, 512, out_dim],
             activation_cls=nn.ReLU,
             batch_norm=True,
             final_bn=False,
             final_relu=False,
         )
-        self.prediction_branch_predictor = SimSiamMLPHead(
+        self.prediction_head = SimSiamMLPHead(
             [out_dim, hid_dim, out_dim],
             activation_cls=nn.ReLU,
             batch_norm=True,
             final_bn=False,
             final_relu=False,
         )
+        if loss_fn:
+            self.loss_fn = loss_fn
+        else:
+            self.loss_fn = torch.nn.CosineSimilarity(dim=1, eps=1e-8)
 
-        # Target branch (momentum updated)
-        self.target_branch_backbone = copy.deepcopy(backbone)
-        self.target_branch_projector = SimSiamMLPHead(
-            [in_dim, hid_dim, out_dim],
-            activation_cls=nn.ReLU,
-            batch_norm=True,
-            final_bn=False,
-            final_relu=False,
-        )
+        self.global_avg_pool = None
+        if avg_pooling:
+            self.global_avg_pool = nn.AdaptiveAvgPool2d((1, 1))
 
-        # Global average pooling layer
-        self.global_avg_pool = nn.AdaptiveAvgPool2d((1, 1))
+    def forward(self, x):
+        f = self.backbone(x)
+        if self.global_avg_pool:
+            f = self.global_avg_pool(f)
+        if self.flatten:
+            f = f.flatten(start_dim=1)
+        z = self.projection_head(f)
+        p = self.prediction_head(z)
+        z = z.detach()
+        return z, p
 
-    @torch.no_grad()
-    def update_target_branch(self) -> None:
-        """Momentum update for the target branch."""
-        for prediction_branch_param, target_branch_param in zip(
-            self.backbone.parameters(), self.target_branch_backbone.parameters()
-        ):
-            target_branch_param.data = (
-                self.momentum * target_branch_param.data
-                + (1.0 - self.momentum) * prediction_branch_param.data
-            )
-        for prediction_branch_param, target_branch_param in zip(
-            self.prediction_branch_projector.parameters(),
-            self.target_branch_projector.parameters(),
-        ):
-            target_branch_param.data = (
-                self.momentum * target_branch_param.data
-                + (1.0 - self.momentum) * prediction_branch_param.data
-            )
+    def _single_step_arbitrary_k(self, batch: Any):
+        # borrowed from lightly
+        # source: https://github.com/lightly-ai/lightly/blob/f5a9f19ac983d88f058030d630761432dbbd98a3/examples/pytorch_lightning/fastsiam.py
+        features = [self.forward(view) for view in batch]
+        zs = torch.stack([z for z, _ in features])
+        ps = torch.stack([p for _, p in features])
 
-    def forward(self, views: Any) -> tuple[torch.Tensor, torch.Tensor]:
-        """Forward pass through the prediction branch and target branches."""
-        # Ensure views are in the correct format (BCHW)
-        if not isinstance(views, list):
-            views = [views]
+        loss = 0.0
+        for i in range(self.k + 1):
+            mask = torch.arange(self.k + 1, device=self.device) != i
+            loss += -self.loss_fn(ps[i], torch.sum(zs[mask], dim=0) / self.k).mean()
+        return loss / (self.k + 1)
 
-        # Process prediction branch
-        prediction_branch_features = self.backbone(views[-1])  # Use the last view
-        prediction_branch_features = self.global_avg_pool(prediction_branch_features)
-        prediction_branch_features = torch.flatten(
-            prediction_branch_features, start_dim=1
-        )
-        prediction_branch_projected = self.prediction_branch_projector(
-            prediction_branch_features
-        )
-        prediction_branch_predicted = self.prediction_branch_predictor(
-            prediction_branch_projected
-        )
-
-        target_branch_projected_list = []
-        with torch.no_grad():
-            for i in range(self.K):
-                # Process target branch
-                target_branch_features = self.target_branch_backbone(views[i])
-                target_branch_features = self.global_avg_pool(target_branch_features)
-                target_branch_features = torch.flatten(
-                    target_branch_features, start_dim=1
-                )
-                target_branch_projected = self.target_branch_projector(
-                    target_branch_features
-                )
-                target_branch_projected_list.append(target_branch_projected)
-
-        avg_target_branch_projected = sum(target_branch_projected_list) / self.K
-
-        return prediction_branch_predicted, avg_target_branch_projected.detach()
-
-    def _single_step(self, batch: Any, K: int, log_prefix: str) -> torch.Tensor:
-        """Perform a single training, validation, or test step."""
-        images, *_ = batch
-
-        # Generate augmented views
-        augmented_views = [
-            torch.stack([self.ensure_tensor(img)[0] for img in images]).to(self.device)
-            for _ in range(K + 1)
-        ]
-
-        # Initialize total loss
-        total_loss = 0
-
-        # Loop over all views as the prediction view
-        for i in range(K + 1):
-            # Prediction branch uses view i
-            prediction_branch_features = self.backbone(augmented_views[i])
-            prediction_branch_features = self.global_avg_pool(
-                prediction_branch_features
-            )
-            prediction_branch_features = torch.flatten(
-                prediction_branch_features, start_dim=1
-            )
-            prediction_branch_projected = self.prediction_branch_projector(
-                prediction_branch_features
-            )
-            prediction_branch_predicted = self.prediction_branch_predictor(
-                prediction_branch_projected
+    def _single_step(self, batch: Any, log_prefix: str) -> torch.Tensor:
+        if len(batch) != self.k + 1:
+            raise RuntimeError(
+                f"expected {self.k + 1} views, but got {len(batch)}, is your Dataset class yielding k+1 views?"
             )
 
-            # Target branch averages over all other views
-            target_branch_projected_list = []
-            with torch.no_grad():
-                for j in range(K + 1):
-                    if j != i:
-                        target_branch_features = self.target_branch_backbone(
-                            augmented_views[j]
-                        )
-                        target_branch_features = self.global_avg_pool(
-                            target_branch_features
-                        )
-                        target_branch_features = torch.flatten(
-                            target_branch_features, start_dim=1
-                        )
-                        target_branch_projected = self.target_branch_projector(
-                            target_branch_features
-                        )
-                        target_branch_projected_list.append(target_branch_projected)
+        # since the user will probably use k = 3 most of the time
+        # lets just inline the loss here
+        if self.k == 3:
+            z0, p0 = self.forward(batch[0])
+            z1, p1 = self.forward(batch[1])
+            z2, p2 = self.forward(batch[2])
+            z3, p3 = self.forward(batch[3])
 
-            avg_target_branch_projected = sum(target_branch_projected_list) / K
+            d1 = self.loss_fn(p0, (z1 + z2 + z3) / 3).mean()
+            d2 = self.loss_fn(p1, (z0 + z2 + z3) / 3).mean()
+            d3 = self.loss_fn(p2, (z0 + z1 + z3) / 3).mean()
+            d4 = self.loss_fn(p3, (z0 + z1 + z2) / 3).mean()
 
-            # Normalize loss before summing
-            avg_target_branch_projected = F.normalize(
-                avg_target_branch_projected, dim=-1, p=2
-            )
+            loss = (-1 / 4) * (d1 + d2 + d3 + d4)
+        else:
+            loss = self._single_step_arbitrary_k(batch)
 
-            # Compute loss for the current view
-            loss = self.fastsiam_loss(
-                prediction_branch_predicted, avg_target_branch_projected.detach()
-            )
-            total_loss += loss
-
-        # Average the loss over all views
-        total_loss /= K + 1
-
-        # Log the loss
         self.log(
             f"{log_prefix}_loss",
-            total_loss,
-            batch_size=len(images),
+            loss,
             on_step=True,
             on_epoch=True,
             prog_bar=True,
         )
-        return total_loss
+        return loss
 
     def training_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
-        return self._single_step(batch, self.K, "train")
+        return self._single_step(batch, "train")
 
     def validation_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
-        return self._single_step(batch, self.K, "val")
+        return self._single_step(batch, "val")
 
     def test_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
-        return self._single_step(batch, self.K, "test")
+        return self._single_step(batch, "test")
 
-    def configure_optimizers(self) -> torch.optim.Optimizer:
-        """Configure the optimizer for training."""
+    def configure_optimizers(self):
         optimizer = torch.optim.SGD(
             self.parameters(), lr=self.lr, momentum=0.9, weight_decay=1e-4
         )
@@ -315,24 +229,3 @@ class FastSiam(L.LightningModule):
             optimizer, T_max=self.trainer.max_epochs
         )
         return [optimizer], [scheduler]
-
-    def ensure_tensor(self, image: torch.Tensor) -> torch.Tensor:
-        """Ensure the input image is a PyTorch tensor with the correct format."""
-        if not isinstance(image, torch.Tensor):
-            # Convert non-tensor input to tensor (assuming numpy array input)
-            image = torch.from_numpy(image).float()
-
-        # Ensure the tensor is in BCHW format (batch, channels, height, width)
-        if len(image.shape) == 3:
-            image = image.unsqueeze(0)  # Add batch dimension if missing
-
-        return image
-
-    @staticmethod
-    def fastsiam_loss(
-        prediction_branch_pred: torch.Tensor, target_branch_target: torch.Tensor
-    ) -> torch.Tensor:
-        """Compute the FastSiam loss (cosine similarity loss)."""
-        prediction_branch_pred = F.normalize(prediction_branch_pred, dim=-1, p=2)
-        target_branch_target = F.normalize(target_branch_target, dim=-1, p=2)
-        return -(prediction_branch_pred * target_branch_target).sum(dim=-1).mean()

--- a/tests/models/ssl/test_fastsiam.py
+++ b/tests/models/ssl/test_fastsiam.py
@@ -19,47 +19,38 @@ class TestFastSiam(unittest.TestCase):
             in_dim=2048,
             hid_dim=512,
             out_dim=128,
-            K=2,
-            momentum=0.996,
-            lr=1e-3,
+            k=2,  # Using k=2 means the batch should contain k+1=3 views
+            lr=0.125,
         )
 
     def test_forward(self):
         # Test the forward pass
-        views = [torch.rand(4, 3, 224, 224) for _ in range(3)]  # Mock 3 augmented views
-        prediction, target = self.model(views)
+        view = torch.rand(
+            4, 3, 224, 224
+        )  # Mock 1 augmented view (forward takes one view)
+        z, p = self.model(view)
 
         # Assertions
-        self.assertEqual(prediction.shape, (4, 128))
-        self.assertEqual(target.shape, (4, 128))
+        self.assertEqual(z.shape, (4, 128))
+        self.assertEqual(p.shape, (4, 128))
+        self.assertFalse(z.requires_grad)
+        self.assertTrue(p.requires_grad)
 
-    def test_update_target_branch(self):
-        # Test momentum update of target branch
-        original_params = [
-            p.clone() for p in self.model.target_branch_backbone.parameters()
-        ]
-        self.model.update_target_branch()
-        updated_params = [p for p in self.model.target_branch_backbone.parameters()]
+    def test_single_step_arbitrary_k(self):
+        # Test the arbitrary k step function
+        # Mock 3 augmented views for k=2
+        batch = tuple([torch.rand(4, 3, 224, 224) for _ in range(3)])
 
-        for orig, updated in zip(original_params, updated_params):
-            self.assertFalse(
-                torch.equal(orig, updated),
-                "Target branch parameters did not update correctly.",
-            )
-
-    def test_fastsiam_loss(self):
-        # Test the FastSiam loss function
-        pred = torch.rand(4, 128)
-        target = torch.rand(4, 128)
-        loss = self.model.fastsiam_loss(pred, target)
+        # Run single step
+        loss = self.model._single_step_arbitrary_k(batch)
 
         # Assertions
         self.assertIsInstance(loss, torch.Tensor)
         self.assertEqual(loss.dim(), 0)
 
     def test_training_step(self):
-        # Mock batch
-        batch = (torch.rand(4, 3, 224, 224),)
+        # Mock batch (k=2 requires 3 views)
+        batch = tuple([torch.rand(4, 3, 224, 224) for _ in range(3)])
 
         # Run training step
         loss = self.model.training_step(batch, 0)
@@ -95,6 +86,59 @@ class TestFastSiam(unittest.TestCase):
 
         # Assertions
         self.assertEqual(output_tensor.shape, (4, 128))
+
+    def test_unexpected_k_error(self):
+        batch = tuple([torch.rand(4, 3, 224, 224) for _ in range(2)])
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"expected 3 views, but got 2, is your Dataset class yielding k\+1 views\?",
+        ):
+            self.model.training_step(batch, 0)
+
+    def test_single_step_k_equals_3(self):
+        model_k3 = FastSiam(backbone=self.mock_backbone, k=3)
+        batch = tuple([torch.rand(4, 3, 224, 224) for _ in range(4)])
+        loss = model_k3.training_step(batch, 0)
+
+        self.assertIsInstance(loss, torch.Tensor)
+        self.assertEqual(loss.dim(), 0)
+
+    def test_avg_pooling_flag(self):
+        model = FastSiam(
+            backbone=self.mock_backbone,
+            in_dim=2048,
+            hid_dim=512,
+            out_dim=128,
+            avg_pooling=False,
+        )
+        self.assertIsNone(model.global_avg_pool)
+
+        view = torch.rand(4, 3, 224, 224)
+        z, p = model(view)
+
+        self.assertEqual(z.shape, (4, 128))
+        self.assertEqual(p.shape, (4, 128))
+
+    def test_flatten_flag(self):
+        mock_backbone = MagicMock(spec=nn.Module)
+        mock_backbone.return_value = torch.rand(4, 2048)
+
+        model = FastSiam(
+            backbone=mock_backbone,
+            in_dim=2048,
+            hid_dim=512,
+            out_dim=128,
+            flatten=False,
+            avg_pooling=False,
+        )
+
+        self.assertFalse(model.flatten)
+
+        view = torch.rand(4, 3, 224, 224)
+        z, p = model(view)
+
+        self.assertEqual(z.shape, (4, 128))
+        self.assertEqual(p.shape, (4, 128))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests to this functionality.
- [X] All tests are passing.
- [X] I have updated the documentation as needed.
- [X] I have followed the project's coding guidelines.
---

Hi, first of all thanks for the implementation.

# Motivation

While reading the FastSiam implementation, I've noticed some divergences when comparing it with the original paper.

Although I have seem good results with the current implementation, I still think it is different from the original paper authors intent.

So this PR is more of a faithful implementation of the paper, than a de-facto "fix".

The main divergences that I observed are:

* 1. It is not a Siamese network: The current implementation does not share weights between the branches.
The paper explicitly states:

> FastSiam extends upon SimSiam and addresses a core weakness of it, namely target instability.

Since SimSiam is an implementation that shares weights between branches, this doesn't seem to be the same algorithm described in the paper.

* 2. $K=1$ does not equate to SimSiam: Since the code uses a target network updated via momentum, if we set $k=1$, the network does not equate to SimSiam (unlike the mathematical formulation in the paper).
In fact, this implementation seems to decay into the BYOL architecture.

And also, a minor issue that doesn't really impact these points is that the `update_target_branch` method was defined, but not called anywhere.
If the user simply just pass the model to `trainer.fit()`, it would equate to dead code and the target network will never be updated.

# Summary of the changes

For $k=3$ I've inlined the loss function because that will probaly be the most common value for $k$ that the user will take, therefore inlining it would be faster than the fallback for arbitrary $k$ that I
used Lightly's implementation as a base.

I've made some *breaking changes* to the arguments of this class because some of them weren't used (like `test_metric` and `num_classes`), others were EMA-related (`momentum`), and I've changed the case of the `K`
argument to follow the style-guide of other classes in Minerva that uses lower case instead.

Also I've the `flatten` and `avg_pooling:` parameter that is useful when not using a CNN-based backend, a similar setup that the `SimCLR` class uses.

And finally, I've added a simple check to garantee the user passes $k+1$ views in his Dataset, because this algorithm assumes that the user will use k views for the target branch, and 1 view for the prediction branch, therefore $k+1$.

# Reference total loss derived from the paper

To help with the review, here are the total loss for specific $k$ that I derived from the paper, and the general formula:

$\mathcal{D}=$ negative cosine similarity
$\text{sg}(x)=$ stop gradient

| $K$ | Formula |
| --- | --- |
| **1** | $\tfrac{1}{2}\left[\mathcal{D}(p_1,\text{sg}(z_2))+\mathcal{D}(p_2,\text{sg}(z_1))\right]$ *(same as SimSiam loss)* |
| **2** | $\tfrac{1}{3}\left[\mathcal{D}\!\left(p_1,\tfrac{\text{sg}(z_2)+\text{sg}(z_3)}{2}\right)+\mathcal{D}\!\left(p_2,\tfrac{\text{sg}(z_1)+\text{sg}(z_3)}{2}\right)+\mathcal{D}\!\left(p_3,\tfrac{\text{sg}(z_1)+\text{sg}(z_2)}{2}\right)\right]$ |
| **3** | $\tfrac{1}{4}\left[\mathcal{D}\!\left(p_1,\tfrac{\text{sg}(z_2)+\text{sg}(z_3)+\text{sg}(z_4)}{3}\right)+\mathcal{D}\!\left(p_2,\tfrac{\text{sg}(z_1)+\text{sg}(z_3)+\text{sg}(z_4)}{3}\right)+\mathcal{D}\!\left(p_3,\tfrac{\text{sg}(z_1)+\text{sg}(z_2)+\text{sg}(z_4)}{3}\right)+\mathcal{D}\!\left(p_4,\tfrac{\text{sg}(z_1)+\text{sg}(z_2)+\text{sg}(z_3)}{3}\right)\right]$ |
| **General** | $\tfrac{1}{K+1}\sum_{i=1}^{K+1} \mathcal{D}\left(p_i,\tfrac{1}{K}\sum_{j=1, j\neq i}^{K+1}\text{sg}(z_j)\right)$ |


# Final Notes

Please let me know if my assertions are incorrect, also, if there is any specific context behind the original design choices that I might have missed, I am more than happy to discuss this further and make any necessary adjustments based on your feedback!
